### PR TITLE
Add renderer trait and optional Bevy support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,8 @@ rand = "0.8"
 crossterm = "0.27"
 ratatui = "0.26"
 image = "0.24"
+bevy = { version = "0.12", optional = true }
+
+[features]
+default = []
+bevy-renderer = ["bevy"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,9 @@ use std::path::Path;
 use image::{RgbaImage, Rgba};
 
 use core::{game::Game, input::handle_input};
-use render::tui_render::{TuiRenderer,init_terminal, shutdown_terminal, GameTerminal};
+use render::{Renderer, tui_render::TuiRenderer};
+#[cfg(feature = "bevy-renderer")]
+use render::bevy_render::BevyRenderer;
 
 pub const MAP_WIDTH: usize = 512;
 pub const MAP_HEIGHT: usize = 256;
@@ -28,8 +30,12 @@ fn main() {
     
 }
 fn run() -> Result<()> {
-    let mut renderer = TuiRenderer::new()?;
-    renderer.init();
+    let mut renderer: Box<dyn Renderer> = if cfg!(feature = "bevy-renderer") {
+        Box::new(BevyRenderer::new()?)
+    } else {
+        Box::new(TuiRenderer::new()?)
+    };
+    renderer.init()?;
 
     let mut player = Player::create_random(MAP_WIDTH / 2, MAP_HEIGHT / 2);
     player.character = Character::create_random(); // or Character::create_human("Name".to_string());
@@ -81,7 +87,7 @@ fn run() -> Result<()> {
         }
     }
     // Cleanup and shutdown
-    renderer.shutdown();
+    renderer.shutdown()?;
     Ok(())  // Add explicit Ok return
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,7 +9,9 @@ pub use crate::core::game::{Game, GamePhase};
 pub use crate::core::input::handle_input;
 
 // Render
-pub use crate::render::tui_render::{TuiRenderer};
+pub use crate::render::{Renderer, tui_render::TuiRenderer};
+#[cfg(feature = "bevy-renderer")]
+pub use crate::render::bevy_render::BevyRenderer;
 
 // Generators
 pub use crate::generators::world_generator::WorldGenerator;

--- a/src/render/bevy_render.rs
+++ b/src/render/bevy_render.rs
@@ -1,0 +1,29 @@
+use crate::core::game::Game;
+use crate::render::Renderer;
+
+#[cfg(feature = "bevy-renderer")]
+use bevy::prelude::*;
+
+pub struct BevyRenderer;
+
+impl BevyRenderer {
+    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self)
+    }
+}
+
+impl Renderer for BevyRenderer {
+    fn init(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        // Real Bevy initialization would go here
+        Ok(())
+    }
+
+    fn render(&mut self, _game: &Game) -> Result<(), Box<dyn std::error::Error>> {
+        // Use Bevy's systems to draw the world
+        Ok(())
+    }
+
+    fn shutdown(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,1 +1,12 @@
+use crate::core::game::Game;
+
+pub trait Renderer {
+    fn init(&mut self) -> Result<(), Box<dyn std::error::Error>>;
+    fn render(&mut self, game: &Game) -> Result<(), Box<dyn std::error::Error>>;
+    fn shutdown(&mut self) -> Result<(), Box<dyn std::error::Error>>;
+}
+
 pub mod tui_render;
+
+#[cfg(feature = "bevy-renderer")]
+pub mod bevy_render;

--- a/src/render/tui_render.rs
+++ b/src/render/tui_render.rs
@@ -5,6 +5,7 @@ use crate::generators::location_generator::{LocationMap, LocationTileType, Featu
 use crate::core::game::{Game, GamePhase};
 use crate::systems::player::Player;
 use crate::systems::position::Position;
+use crate::render::Renderer;
 use ratatui::{
     backend::CrosstermBackend,
     layout::{Rect, Layout, Constraint, Direction},
@@ -598,4 +599,18 @@ pub fn shutdown_terminal(terminal: &mut GameTerminal) -> Result<(), Box<dyn std:
     terminal.show_cursor()?;
     
     Ok(())
+}
+
+impl Renderer for TuiRenderer {
+    fn init(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        TuiRenderer::init(self)
+    }
+
+    fn render(&mut self, game: &Game) -> Result<(), Box<dyn std::error::Error>> {
+        TuiRenderer::render(self, game)
+    }
+
+    fn shutdown(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        TuiRenderer::shutdown(self)
+    }
 }


### PR DESCRIPTION
## Summary
- add a `Renderer` trait and expose it in the prelude
- implement the trait for `TuiRenderer`
- stub out a `BevyRenderer` behind the `bevy-renderer` feature
- update the game loop to select a renderer via feature flag
- declare optional `bevy` dependency in `Cargo.toml`

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684e7591be288322b718215f45271e35